### PR TITLE
Update billinginfo + Add reactivate support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ test.py
 */__pycache__/*
 mocurly.egg-info
 *.egg
+
+# Editor files
+.idea

--- a/mocurly/endpoints.py
+++ b/mocurly/endpoints.py
@@ -146,9 +146,6 @@ class AccountsEndpoint(BaseRecurlyEndpoint):
             billing_info['account'] = create_info['account_code']
             billing_info_backend.add_object(create_info[AccountsEndpoint.pk_attr], billing_info)
             del create_info['billing_info']
-        else:
-            account = create_info[AccountsEndpoint.pk_attr]
-            billing_info_backend.add_object(account, {'account': account})
         create_info['hosted_login_token'] = self.generate_id()
         create_info['created_at'] = current_time().isoformat()
         return super(AccountsEndpoint, self).create(create_info, format=format)

--- a/mocurly/endpoints.py
+++ b/mocurly/endpoints.py
@@ -791,6 +791,7 @@ class SubscriptionsEndpoint(BaseRecurlyEndpoint):
             uri_out['invoice_uri'] = invoices_endpoint.get_object_uri(pseudo_invoice_object)
         uri_out['plan_uri'] = plans_endpoint.get_object_uri(obj['plan'])
         uri_out['cancel_uri'] = uri_out['object_uri'] + '/cancel'
+        uri_out['reactivate_uri'] = uri_out['object_uri'] + '/reactivate'
         uri_out['terminate_uri'] = uri_out['object_uri'] + '/terminate'
         return uri_out
 
@@ -965,6 +966,15 @@ class SubscriptionsEndpoint(BaseRecurlyEndpoint):
             'state': 'canceled',
             'expires_at': subscription['current_period_ends_at'],
             'canceled_at': current_time().isoformat()
+        }), format=format)
+
+    @details_route('PUT', 'reactivate')
+    def reactivate_subscription(self, pk, reactivate_info, format=format):
+        subscription = SubscriptionsEndpoint.backend.get_object(pk)
+        return self.serialize(SubscriptionsEndpoint.backend.update_object(pk, {
+            'state': 'active',
+            'expires_at': None,
+            'canceled_at': None
         }), format=format)
 
 accounts_endpoint = AccountsEndpoint()

--- a/mocurly/endpoints.py
+++ b/mocurly/endpoints.py
@@ -193,7 +193,11 @@ class AccountsEndpoint(BaseRecurlyEndpoint):
 
     @details_route('PUT', 'billing_info')
     def update_billing_info(self, pk, update_info, format=BaseRecurlyEndpoint.XML):
-        out = billing_info_backend.update_object(pk, update_info)
+        if billing_info_backend.has_object(pk):
+            out = billing_info_backend.update_object(pk, update_info)
+        else:
+            update_info['account'] = self.pk_attr
+            out = billing_info_backend.add_object(pk, update_info)
         return self.serialize_billing_info(out, format=format)
 
     @details_route('DELETE', 'billing_info')

--- a/mocurly/endpoints.py
+++ b/mocurly/endpoints.py
@@ -971,6 +971,8 @@ class SubscriptionsEndpoint(BaseRecurlyEndpoint):
     @details_route('PUT', 'reactivate')
     def reactivate_subscription(self, pk, reactivate_info, format=format):
         subscription = SubscriptionsEndpoint.backend.get_object(pk)
+        if not subscription['state'] == 'canceled':
+            raise ResponseError(400, '')
         return self.serialize(SubscriptionsEndpoint.backend.update_object(pk, {
             'state': 'active',
             'expires_at': None,

--- a/mocurly/endpoints.py
+++ b/mocurly/endpoints.py
@@ -146,6 +146,9 @@ class AccountsEndpoint(BaseRecurlyEndpoint):
             billing_info['account'] = create_info['account_code']
             billing_info_backend.add_object(create_info[AccountsEndpoint.pk_attr], billing_info)
             del create_info['billing_info']
+        else:
+            account = create_info[AccountsEndpoint.pk_attr]
+            billing_info_backend.add_object(account, {'account': account})
         create_info['hosted_login_token'] = self.generate_id()
         create_info['created_at'] = current_time().isoformat()
         return super(AccountsEndpoint, self).create(create_info, format=format)

--- a/mocurly/templates/subscription.xml
+++ b/mocurly/templates/subscription.xml
@@ -55,5 +55,6 @@
         {% endfor %}
     </subscription_add_ons>
     <a name="cancel" href="{{ subscription.uris.cancel_uri }}" method="put"/>
+    <a name="reactivate" href="{{ subscription.uris.reactivate_uri }}" method="put"/>
     <a name="terminate" href="{{ subscription.uris.terminate_uri }}" method="put"/>
 </subscription>

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -110,6 +110,24 @@ class TestAccount(unittest.TestCase):
             else:
                 self.assertEqual(getattr(account, k), v)
 
+    def test_simple_account_update_billing_info(self):
+        # Create a simple account
+        recurly.Account(**self.base_account_data).save()
+
+        # Verify account has no billing info
+        recurly_account = recurly.Account.get(self.base_account_data['account_code'])
+        self.assertRaises(AttributeError, lambda: recurly_account.billing_info)
+
+        # Update the billing info using the update_billing_info method
+        billing_info = recurly.BillingInfo(**self.base_billing_info_data)
+        recurly_account.update_billing_info(billing_info)
+
+        # Verify billing info object exists in backend
+        self.assertTrue(mocurly.backend.billing_info_backend.has_object(self.base_account_data['account_code']))
+        new_billing_info = mocurly.backend.billing_info_backend.get_object(self.base_account_data['account_code'])
+        for k, v in self.base_billing_info_data.items():
+            self.assertEqual(new_billing_info[k], v)
+
     def test_delete_billing_info(self):
         self.base_account_data['hosted_login_token'] = 'abcd1234'
         self.base_account_data['created_at'] = '2014-08-11'

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -283,7 +283,7 @@ class TestSubscriptions(unittest.TestCase):
         # 29 / 60, because today doesn't count
         self.assertEqual(refund_transaction['amount_in_cents'], -int(original_transaction['amount_in_cents'] * (29.0 / 60)))
 
-    def test_subscription_cancel(self):
+    def test_subscription_cancel_reactivate(self):
         # add a sample plan to the plans backend
         mocurly.backend.plans_backend.add_object(self.base_backed_plan_data['plan_code'], self.base_backed_plan_data)
         # add an active subscription
@@ -294,6 +294,12 @@ class TestSubscriptions(unittest.TestCase):
         # now cancel it and verify it was canceled
         new_subscription.cancel()
         self.assertEqual(new_subscription.state, 'canceled')
+
+        # now reactivate it and verify it was reactivated
+        new_subscription.reactivate()
+        self.assertEqual(new_subscription.state, 'active')
+        self.assertEqual(new_subscription.canceled_at, None)
+        self.assertEqual(new_subscription.expires_at, None)
 
     def test_coupon_redemption_percent_discount(self):
         # add a sample plan to the plans backend

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -2,6 +2,8 @@ import unittest
 import datetime
 import iso8601
 import recurly
+from recurly.errors import BadRequestError
+
 recurly.API_KEY = 'blah'
 
 import mocurly.core
@@ -290,6 +292,10 @@ class TestSubscriptions(unittest.TestCase):
         new_subscription = recurly.Subscription(**self.base_subscription_data)
         new_subscription.save()
         self.assertEqual(new_subscription.state, 'active')
+
+        # trying to reactivate an active subscription should fail
+        with self.assertRaises(BadRequestError):
+           new_subscription.reactivate()
 
         # now cancel it and verify it was canceled
         new_subscription.cancel()


### PR DESCRIPTION
This fixes a bug where after creating an account without billing info, the account would throw an exception on `update_billing_info`.
