### PR TITLE
Overriding trial_ends for a subscription

### DIFF
--- a/mocurly/endpoints.py
+++ b/mocurly/endpoints.py
@@ -2,12 +2,15 @@
 
 Each endpoint class will define the CRUD interface into the resource.
 """
+from datetime import datetime
+
 import recurly
 import six
 import random
 import string
 import dateutil.relativedelta
 import dateutil.parser
+from dateutil.tz import tzutc
 
 from .utils import current_time
 from .errors import TRANSACTION_ERRORS, ResponseError
@@ -868,7 +871,9 @@ class SubscriptionsEndpoint(BaseRecurlyEndpoint):
         self.hydrate_foreign_keys(new_sub)
 
         if defaults['state'] == 'active':
-            if 'trial_started_at' in defaults:
+            # if trial_ends_at is set but is not in the future, the trial has ended
+            if 'trial_started_at' in defaults and \
+                ('trial_ends_at' not in defaults or self._parse_isoformat(defaults['trial_ends_at']) >= datetime.now(tzutc())):
                 # create a transaction and invoice for the trial
                 new_transaction = {}
                 new_transaction['account'] = {}

--- a/mocurly/templates/billing_info.xml
+++ b/mocurly/templates/billing_info.xml
@@ -90,4 +90,9 @@
     {% else %}
         <last_four nil="nil"></last_four>
     {% endif %}
+    {% if billing_info.paypal_billing_agreement_id %}
+        <paypal_billing_agreement_id>{{ billing_info.paypal_billing_agreement_id }}</paypal_billing_agreement_id>
+    {% else %}
+        <paypal_billing_agreement_id nil="nil"></paypal_billing_agreement_id>
+    {% endif %}
 </billing_info>

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -199,7 +199,7 @@ class TestAccount(unittest.TestCase):
                 continue # skip
             self.assertEqual(getattr(billing_info, k), v)
 
-    def test_update_billing_info(self):
+    def test_update_creditcard_billing_info(self):
         self.base_account_data['hosted_login_token'] = 'abcd1234'
         self.base_account_data['created_at'] = '2014-08-11'
         mocurly.backend.accounts_backend.add_object(self.base_account_data['account_code'], self.base_account_data)
@@ -226,6 +226,26 @@ class TestAccount(unittest.TestCase):
         self.assertEqual(billing_info_backed['verification_value'], '123')
         self.assertEqual(billing_info_backed['month'], '11')
         self.assertEqual(billing_info_backed['year'], '2015')
+
+    def test_update_paypal_billing_info(self):
+        self.base_account_data['hosted_login_token'] = 'abcd1234'
+        self.base_account_data['created_at'] = '2014-08-11'
+        mocurly.backend.accounts_backend.add_object(self.base_account_data['account_code'], self.base_account_data)
+        self.base_billing_info_data['account'] = self.base_account_data['account_code']
+        mocurly.backend.billing_info_backend.add_object(self.base_account_data['account_code'], self.base_billing_info_data)
+
+        account = recurly.Account.get(self.base_account_data['account_code'])
+        billing_info = account.billing_info
+        billing_info.first_name = 'Verena'
+        billing_info.last_name = 'Example'
+        billing_info.paypal_billing_agreement_id = 'PP-7594'
+        billing_info.save()
+
+        self.assertEqual(len(mocurly.backend.billing_info_backend.datastore), 1)
+        billing_info_backed = mocurly.backend.billing_info_backend.get_object(self.base_account_data['account_code'])
+        self.assertEqual(billing_info_backed['first_name'], 'Verena')
+        self.assertEqual(billing_info_backed['last_name'], 'Example')
+        self.assertEqual(billing_info_backed['paypal_billing_agreement_id'], 'PP-7594')
 
     def test_update_account_with_billing_info(self):
         # Case 1: account exists, but has no billing data

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -194,6 +194,36 @@ class TestSubscriptions(unittest.TestCase):
         self.assertEqual(account_subscriptions[0].uuid, new_subscription.uuid)
         self.assertEqual(account_subscriptions[0].state, 'active')
 
+    def test_trial_override_subscription_creation(self):
+        # add a sample plan to the plans backend
+        self.base_backed_plan_data['trial_interval_length'] = 1
+        mocurly.backend.plans_backend.add_object(self.base_backed_plan_data['plan_code'], self.base_backed_plan_data)
+
+        self.assertEqual(len(mocurly.backend.subscriptions_backend.datastore), 0)
+
+        # Make the trial immediately expire
+        self.base_subscription_data['trial_ends_at'] = datetime.datetime.utcnow()
+        new_subscription = recurly.Subscription(**self.base_subscription_data)
+        new_subscription.save()
+
+        self.assertEqual(len(mocurly.backend.subscriptions_backend.datastore), 1)
+
+        # Make sure a new transaction and invoice was created with it
+        invoice = new_subscription.invoice()
+        # The invoice should not contain 0 (trial cost) but the actual cost of the subscription since the trial has expired immediately
+        self.assertNotEqual(invoice.total_in_cents, 0)
+
+        transactions = invoice.transactions
+        self.assertEqual(len(transactions), 1)
+        self.assertEqual(transactions[0].subscription().uuid, new_subscription.uuid)
+
+        # Make sure we can reference the subscription from the account
+        account = new_subscription.account()
+        account_subscriptions = account.subscriptions()
+        self.assertEqual(len(account_subscriptions), 1)
+        self.assertEqual(account_subscriptions[0].uuid, new_subscription.uuid)
+        self.assertEqual(account_subscriptions[0].state, 'active')
+
     def test_subscriptions_with_addons(self):
         # add a sample plan to the plans backend
         mocurly.backend.plans_backend.add_object(self.base_backed_plan_data['plan_code'], self.base_backed_plan_data)


### PR DESCRIPTION
When trial_ends_at was passed to a new subscription, Mocurly still would create an invoice for the trial and not the subscription.
