### PR TITLE
Fix typo in account address country

### DIFF
--- a/mocurly/templates/account.xml
+++ b/mocurly/templates/account.xml
@@ -72,7 +72,7 @@
                 <zip nil="nil"></zip>
             {% endif %}
             {% if account.address.country %}
-                <country>{{ account.addresscountry }}</country>
+                <country>{{ account.address.country }}</country>
             {% else %}
                 <country nil="nil"></country>
             {% endif %}

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -23,7 +23,8 @@ class TestAccount(unittest.TestCase):
                 'address1': '123 Jackson St.',
                 'address2': 'Data City',
                 'state': 'CA',
-                'zip': '94105'
+                'zip': '94105',
+                'country': 'USA'
             }
         self.base_billing_info_data = {
                 'first_name': 'Foo',


### PR DESCRIPTION
This fixes https://github.com/Captricity/mocurly/issues/18, which was caused by an embarrassing typo. Also added a regression test to verify the fix.